### PR TITLE
feat(config,deps): ✨ add environment variable parsing with Zod

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default withNuxt(
 
   }, {
     rules: {
+      "ts/no-redeclare": ["off"],
       "ts/consistent-type-definitions": ["error", "type"],
       "no-console": ["warn"],
       "antfu/no-top-level-await": ["off"],

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,7 @@
 import tailwindcss from "@tailwindcss/vite";
 
+import "./src/lib/env";
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   srcDir: "src/",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "eslint": "^9.26.0",
     "nuxt": "^3.17.1",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "zod": "^3.24.3"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       vue-router:
         specifier: ^4.5.1
         version: 4.5.1(vue@3.5.13(typescript@5.8.3))
+      zod:
+        specifier: ^3.24.3
+        version: 3.24.3
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^4.12.0

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+import { tryParseEnv } from "./try-parse-env";
+
+const EnvSchema = z.object({
+  NODE_ENV: z.enum(["development", "production"]).default("development"),
+});
+
+export type EnvSchema = z.infer<typeof EnvSchema>;
+
+tryParseEnv(EnvSchema);
+
+// eslint-disable-next-line node/no-process-env
+export const env = EnvSchema.parse(process.env);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -8,7 +8,4 @@ const EnvSchema = z.object({
 
 export type EnvSchema = z.infer<typeof EnvSchema>;
 
-tryParseEnv(EnvSchema);
-
-// eslint-disable-next-line node/no-process-env
-export const env = EnvSchema.parse(process.env);
+export const env = tryParseEnv(EnvSchema);

--- a/src/lib/try-parse-env.ts
+++ b/src/lib/try-parse-env.ts
@@ -8,7 +8,8 @@ export function tryParseEnv<T extends ZodRawShape>(
   buildEnv: Record<string, string | undefined> = process.env,
 ) {
   try {
-    EnvSchema.parse(buildEnv);
+    const parsedEnv = EnvSchema.parse(buildEnv);
+    return parsedEnv;
   }
   catch (error) {
     if (error instanceof ZodError) {

--- a/src/lib/try-parse-env.ts
+++ b/src/lib/try-parse-env.ts
@@ -22,6 +22,7 @@ export function tryParseEnv<T extends ZodRawShape>(
     }
     else {
       console.error(error);
+      throw error;
     }
   }
 }

--- a/src/lib/try-parse-env.ts
+++ b/src/lib/try-parse-env.ts
@@ -1,0 +1,27 @@
+/* eslint-disable node/no-process-env */
+import type { ZodObject, ZodRawShape } from "zod";
+
+import { ZodError } from "zod";
+
+export function tryParseEnv<T extends ZodRawShape>(
+  EnvSchema: ZodObject<T>,
+  buildEnv: Record<string, string | undefined> = process.env,
+) {
+  try {
+    EnvSchema.parse(buildEnv);
+  }
+  catch (error) {
+    if (error instanceof ZodError) {
+      let message = "Missing required values in .env:\n";
+      error.issues.forEach((issue) => {
+        message += `${issue.path[0]}\n`;
+      });
+      const e = new Error(message);
+      e.stack = "";
+      throw e;
+    }
+    else {
+      console.error(error);
+    }
+  }
+}


### PR DESCRIPTION
- Introduced a new env.ts file to handle environment variable validation using Zod
- Created a try-parse-env.ts utility to parse and validate environment variables against a defined schema
- Updated nuxt.config.ts to import the new env module for environment configuration
- Added Zod as a dependency in package.json to support the new validation logic
- Modified eslint.config.js to disable the "no-redeclare" rule for TypeScript
- Updated pnpm-lock.yaml to reflect the addition of the Zod dependency